### PR TITLE
Ruby2.7.1に合わせ、parserのバージョンを指定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'carrierwave'
+gem 'parser', '< 2.7.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.20.0)
-    parser (2.7.2.0)
+    parser (2.7.1.5)
       ast (~> 2.4.1)
     public_suffix (4.0.6)
     puma (4.3.6)
@@ -246,6 +246,7 @@ DEPENDENCIES
   carrierwave
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  parser (< 2.7.2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rubocop-fjord


### PR DESCRIPTION
## 目的
- Rubocopの以下のエラーを解消する

```
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.2-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

## 変更事項
- Rubocopで使用するgem:parserのバージョンを2.7.2.0未満に指定
    - 2.7.2.0からはRuby2.7.2のパーサーに追随する。

## 申し送り事項
- なおRuby2.7.1と2.7.2のパーサーには差分はないと思われるので、本PR以前のRubocopについても特に問題はないです。
    - [\* Bump 2\.7 branch to 2\.7\.2 by koic · Pull Request \#748 · whitequark/parser](https://github.com/whitequark/parser/pull/748)